### PR TITLE
homework 3

### DIFF
--- a/Client/src/main/java/ru/gb/Client.java
+++ b/Client/src/main/java/ru/gb/Client.java
@@ -1,0 +1,67 @@
+package ru.gb;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import ru.gb.handler.JsonDecoder;
+import ru.gb.handler.JsonEncoder;
+import ru.gb.message.DownloadFileRequestMessage;
+
+import java.util.Scanner;
+
+public class Client {
+
+    private static final int PORT = 9000;
+
+    public static void main(String[] args) throws Exception {
+
+        NioEventLoopGroup workerGroup = new NioEventLoopGroup(1);
+        try {
+            Bootstrap bootstrap = new Bootstrap()
+                    .group(workerGroup)
+                    .channel(NioSocketChannel.class)
+                    .option(ChannelOption.SO_KEEPALIVE, true)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) {
+                            ch.pipeline().addLast(
+                                    new LengthFieldBasedFrameDecoder(1024 * 1024, 0, 3, 0, 3),
+                                    new LengthFieldPrepender(3),
+                                    new JsonDecoder(),
+                                    new JsonEncoder(),
+                                    new ClientMessageHandler()
+                            );
+                        }
+                    });
+            // Start the client.
+            Channel channel = bootstrap.connect("localhost", PORT).sync().channel();
+            Scanner scanner = new Scanner(System.in);
+            while (true) {
+                // Request with empty body for show available files list
+                channel.writeAndFlush(new DownloadFileRequestMessage());
+
+                String input = scanner.nextLine();
+                if ("q".equals(input)) {
+                    break;
+                }
+
+                final DownloadFileRequestMessage requestMessage = new DownloadFileRequestMessage();
+                requestMessage.setPath(input);
+                channel.writeAndFlush(requestMessage);
+            }
+            channel.close();
+
+            // Wait until the connection is closed.
+            channel.closeFuture().sync();
+        } finally {
+            System.out.println("By ;)");
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/Client/src/main/java/ru/gb/ClientMessageHandler.java
+++ b/Client/src/main/java/ru/gb/ClientMessageHandler.java
@@ -1,0 +1,33 @@
+package ru.gb;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import ru.gb.message.FileMessage;
+import ru.gb.message.Message;
+import ru.gb.message.TextMessage;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+public class ClientMessageHandler extends SimpleChannelInboundHandler<Message> {
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Message msg) {
+        if (msg instanceof TextMessage) {
+            var message = (TextMessage) msg;
+            System.out.println(message.getText());
+        }
+
+        if (msg instanceof FileMessage) {
+            var message = (FileMessage) msg;
+            final String homeDir = System.getProperty("user.home");
+            final String path = homeDir + System.getProperty("file.separator") + message.getName();
+            try (final RandomAccessFile raf = new RandomAccessFile(path, "rw")) {
+                raf.write(message.getContent());
+            } catch (IOException e) {
+                e.printStackTrace();
+                return;
+            }
+            System.out.printf("The file named \"%s\" was uploaded successfully.%nPath: %s%n%n", message.getName(), path);
+        }
+    }
+}

--- a/FileServer/src/main/java/ru/gb/Server.java
+++ b/FileServer/src/main/java/ru/gb/Server.java
@@ -1,0 +1,54 @@
+package ru.gb;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import ru.gb.handler.JsonDecoder;
+import ru.gb.handler.JsonEncoder;
+
+public final class Server {
+
+    private static final int PORT = 9000;
+
+    public static void main(String[] args) throws Exception {
+
+        // Configure the server.
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .option(ChannelOption.SO_BACKLOG, 100)
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel ch) throws Exception {
+                            ch.pipeline().addLast(
+                                    new LengthFieldBasedFrameDecoder(1024 * 1024, 0, 3, 0, 3),
+                                    new LengthFieldPrepender(3),
+                                    new JsonDecoder(),
+                                    new JsonEncoder(),
+                                    new ServerMessageHandler());
+                        }
+                    });
+
+            // Start the server.
+            ChannelFuture f = b.bind(PORT).sync();
+            System.out.println("Server started...");
+
+            // Wait until the server socket is closed.
+            f.channel().closeFuture().sync();
+        } finally {
+            // Shut down all event loops to terminate all threads.
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/FileServer/src/main/java/ru/gb/ServerMessageHandler.java
+++ b/FileServer/src/main/java/ru/gb/ServerMessageHandler.java
@@ -1,0 +1,77 @@
+package ru.gb;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import ru.gb.message.DownloadFileRequestMessage;
+import ru.gb.message.FileMessage;
+import ru.gb.message.Message;
+import ru.gb.message.TextMessage;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+public class ServerMessageHandler extends SimpleChannelInboundHandler<Message> {
+
+    private static final FileResourcesUtils resources = new FileResourcesUtils();
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        TextMessage textMessage = new TextMessage();
+        textMessage.setText("Welcome :)");
+        ctx.writeAndFlush(textMessage);
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, Message msg) {
+
+        if (msg instanceof DownloadFileRequestMessage) {
+            var message = (DownloadFileRequestMessage) msg;
+
+            if (message.getPath() == null) {
+                sendFileListRequest(ctx);
+                return;
+            }
+
+            String path = message.getPath();
+            File file = resources.getFileFromResource(path);
+            if (file == null) {
+                TextMessage errorMessage = new TextMessage();
+                errorMessage.setText("ERROR: Path [" + path + "] not found.");
+                ctx.writeAndFlush(errorMessage);
+                return;
+            }
+            try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+                final FileMessage fileMessage = new FileMessage();
+                byte[] content = new byte[(int) raf.length()];
+                raf.read(content);
+                fileMessage.setName(file.getName());
+                fileMessage.setContent(content);
+                ctx.writeAndFlush(fileMessage);
+            } catch (IOException e) {
+                e.printStackTrace();
+                TextMessage errorMessage = new TextMessage();
+                errorMessage.setText("ERROR: " + e.getClass().getSimpleName() + ": " + e.getMessage() + "\n");
+                ctx.writeAndFlush(errorMessage);
+            }
+        }
+
+        if (msg instanceof TextMessage) {
+            var message = (TextMessage) msg;
+            System.out.println("Message from client: " + message.getText());
+        }
+    }
+
+    private void sendFileListRequest(ChannelHandlerContext ctx) {
+        TextMessage textMessage = new TextMessage();
+        StringBuilder sb = new StringBuilder();
+        sb
+                .append("Enter the name of the download file or type \"q\" to exit.\n")
+                .append("Available files on server:\n");
+        for (String fileName : resources.getResourceFiles()) {
+            sb.append(fileName).append("\n");
+        }
+        textMessage.setText(sb.toString());
+        ctx.writeAndFlush(textMessage);
+    }
+}


### PR DESCRIPTION
Простая реализация для маленьких файлов (как на уроке).

Для работы с большими файлами, пробовал прикрутить хендлер `ChunkedWriteHandler`, из официального [примера](https://github.com/netty/netty/tree/4.1/example/src/main/java/io/netty/example/file), но не придумал как правильно организовать `pipeline` с учётом наших `JsonDecoder/Encoder`.
т.е. когда мы на сервере делаем вот так: `ctx.write(new ChunkedFile(randomAccessFile))` по итогу клиенту летят просто пакеты байтов. В итоге фейл происходит в хендлере `JsonDecoder`.
Смысл моих попыток заключался в удалении из пайплайна (в рантайме) хендлера JsonDecoder и замене его на другую реализацию  для сборки файла из байтов приходящих от `ChunkedWriteHandler`.
В итоге я потерпел неудачу) Кстати модификация пайплайна в рантайме это нормальная практика?.
Ну а вносить изменения в по факту общий для сервера и клиента `JsonDecoder`, мне показалось не правильно.

Файлы хранятся в папке `resources` модуля `FileServer`
Выбранный пользователем файл сохраняется в домашнюю директорию `System.getProperty("user.home")`
Скриншот диалога на клиенте:
![image](https://user-images.githubusercontent.com/10568936/142744784-e5703554-48c7-4312-a91a-e7c1840bce7d.png)
